### PR TITLE
Add expense receipt upload and delete endpoints with Cloudinary

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ psycopg2-binary = "*"
 python-dotenv = "*"
 flask-cors = "*"
 gunicorn = "*"
-cloudinary = "*"
 flask-admin = "==2.0.0"
 typing-extensions = "*"
 wtforms = "==3.1.2"
@@ -22,6 +21,7 @@ sqlalchemy = "*"
 flask-jwt-extended = "*"
 flask-bcrypt = "*"
 flask-mail = "*"
+cloudinary = "*"
 
 [requires]
 python_version = "3.13"
@@ -29,10 +29,8 @@ python_version = "3.13"
 [scripts]
 # ── Dev workflow (no data loss: incremental migrate + upgrade + server) ──
 dev="bash ./scripts/migrate_and_run.sh"
-
 # ── Reset workflow (full DB reset + init + migrate + upgrade + server) ───
 reset="bash ./scripts/reset_and_run.sh"
-
 # ── Low-level commands (use individually if needed) ──────────────────────
 start="flask run -p 3001 -h 0.0.0.0"
 init="flask db init"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -103,11 +103,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de",
-                "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
+                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
+                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.10.5"
+            "version": "==2026.2.25"
         },
         "click": {
             "hashes": [
@@ -653,11 +653,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
-                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.5.0"
+            "version": "==2.6.3"
         },
         "werkzeug": {
             "hashes": [

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -9,9 +9,12 @@ db = SQLAlchemy()
 
 # Tabla intermedia para la relación N:N
 user_group = db.Table('user_group',
-    db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
-    db.Column('group_id', db.Integer, db.ForeignKey('group.id'), primary_key=True)
-)
+                      db.Column('user_id', db.Integer, db.ForeignKey(
+                          'user.id'), primary_key=True),
+                      db.Column('group_id', db.Integer, db.ForeignKey(
+                          'group.id'), primary_key=True)
+                      )
+
 
 class User(db.Model):
     """
@@ -24,7 +27,8 @@ class User(db.Model):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(String(120), nullable=False)
-    email: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(
+        String(120), unique=True, nullable=False)
     password: Mapped[str] = mapped_column(nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean(), nullable=False)
 
@@ -70,21 +74,28 @@ class BlockedToken(db.Model):
         DateTime, nullable=False, default=datetime.utcnow
     )
 
+
 class Group(db.Model):
     __tablename__ = "group"
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     category: Mapped[str] = mapped_column(String(80), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
-    created_by: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow)
+    created_by: Mapped[int] = mapped_column(
+        ForeignKey("user.id"), nullable=False)
 
-    creator: Mapped["User"] = relationship("User", back_populates="groups_created")
-    
+    creator: Mapped["User"] = relationship(
+        "User", back_populates="groups_created")
+
     # RELACIÓN PRINCIPAL: Usamos la tabla intermedia GroupMember
-    members: Mapped[list["GroupMember"]] = relationship("GroupMember", back_populates="group", cascade="all, delete-orphan")
-    
-    invitations: Mapped[list["Invitation"]] = relationship("Invitation", back_populates="group", cascade="all, delete-orphan")
-    expenses: Mapped[list["Expense"]] = relationship("Expense", back_populates="group", cascade="all, delete-orphan")
+    members: Mapped[list["GroupMember"]] = relationship(
+        "GroupMember", back_populates="group", cascade="all, delete-orphan")
+
+    invitations: Mapped[list["Invitation"]] = relationship(
+        "Invitation", back_populates="group", cascade="all, delete-orphan")
+    expenses: Mapped[list["Expense"]] = relationship(
+        "Expense", back_populates="group", cascade="all, delete-orphan")
 
     def serialize(self):
         return {
@@ -97,16 +108,21 @@ class Group(db.Model):
             "created_at": self.created_at.isoformat()
         }
 
+
 class GroupMember(db.Model):
     __tablename__ = "group_member"
     id: Mapped[int] = mapped_column(primary_key=True)
-    group_id: Mapped[int] = mapped_column(ForeignKey("group.id"), nullable=False)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("group.id"), nullable=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)
-    joined_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow)
 
     # El back_populates debe coincidir EXACTAMENTE con el nombre en la clase Group
     group: Mapped["Group"] = relationship("Group", back_populates="members")
-    user: Mapped["User"] = relationship("User", back_populates="group_memberships")
+    user: Mapped["User"] = relationship(
+        "User", back_populates="group_memberships")
+
     def serialize(self):
         return {
             "id": self.id,
@@ -139,15 +155,20 @@ class Expense(db.Model):
     )
 
     # grupo al que pertenece el gasto
-    group_id: Mapped[int] = mapped_column(ForeignKey("group.id"), nullable=False)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("group.id"), nullable=False)
 
     # usuario que pagó el gasto
     paid_by: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)
 
+    # url del recibo/comprobante
+    receipt_url: Mapped[str] = mapped_column(String(500), nullable=True)
+
     # RELATIONS
     group: Mapped["Group"] = relationship("Group", back_populates="expenses")
 
-    payer: Mapped["User"] = relationship("User", back_populates="expenses_paid")
+    payer: Mapped["User"] = relationship(
+        "User", back_populates="expenses_paid")
 
     participants: Mapped[list["ExpenseParticipant"]] = relationship(
         "ExpenseParticipant", back_populates="expense", cascade="all, delete-orphan"
@@ -160,8 +181,10 @@ class Expense(db.Model):
             "amount": float(self.amount),
             "date": self.date.isoformat(),
             "group_id": self.group_id,
-            "paid_by": self.paid_by
+            "paid_by": self.paid_by,
+            "receipt_url": self.receipt_url
         }
+
 
 class ExpenseParticipant(db.Model):
     """
@@ -174,15 +197,18 @@ class ExpenseParticipant(db.Model):
     id: Mapped[int] = mapped_column(primary_key=True)
 
     # referencia al gasto
-    expense_id: Mapped[int] = mapped_column(ForeignKey("expense.id"), nullable=False)
+    expense_id: Mapped[int] = mapped_column(
+        ForeignKey("expense.id"), nullable=False)
 
     # usuario que participa en el gasto
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)
 
     # RELATIONS
-    expense: Mapped["Expense"] = relationship("Expense", back_populates="participants")
+    expense: Mapped["Expense"] = relationship(
+        "Expense", back_populates="participants")
 
-    user: Mapped["User"] = relationship("User", back_populates="expense_participations")
+    user: Mapped["User"] = relationship(
+        "User", back_populates="expense_participations")
 
     def serialize(self):
         return {
@@ -190,17 +216,22 @@ class ExpenseParticipant(db.Model):
             "expense_id": self.expense_id,
             "user_id": self.user_id
         }
-    
-#Invitacion
+
+# Invitacion
+
+
 class Invitation(db.Model):
     __tablename__ = "invitation"
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String(120), nullable=False)
-    token: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, default=lambda: str(uuid.uuid4()))
-    group_id: Mapped[int] = mapped_column(ForeignKey("group.id"), nullable=False)
+    token: Mapped[str] = mapped_column(
+        String(255), unique=True, nullable=False, default=lambda: str(uuid.uuid4()))
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("group.id"), nullable=False)
     is_used: Mapped[bool] = mapped_column(Boolean(), default=False)
 
-    group: Mapped["Group"] = relationship("Group", back_populates="invitations")
+    group: Mapped["Group"] = relationship(
+        "Group", back_populates="invitations")
 
     def serialize(self):
         return {
@@ -210,6 +241,3 @@ class Invitation(db.Model):
             "group_id": self.group_id,
             "is_used": self.is_used
         }
-    
-
-

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -15,6 +15,7 @@ from api.models import (
     Invitation
 )
 from flask_mail import Message
+import cloudinary.uploader
 from api.utils import generate_sitemap, APIException
 from flask_cors import CORS
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity, get_jwt
@@ -416,3 +417,71 @@ def send_invitation():
         # Si algo falla, hacemos rollback para no dejar invitaciones huérfanas
         db.session.rollback()
         return jsonify({"msg": "Error processing invitation", "error": str(e)}), 500
+
+
+# ===============================
+# RECEIPTS (SUBIR / ELIMINAR)
+# ===============================
+
+@api.route('/expense/<int:expense_id>/receipt', methods=['POST'])
+@jwt_required()
+def upload_receipt(expense_id):
+    user_id = int(get_jwt_identity())
+
+    expense = Expense.query.get(expense_id)
+    if not expense:
+        return jsonify({"error": "Expense not found"}), 404
+
+    membership = GroupMember.query.filter_by(
+        group_id=expense.group_id,
+        user_id=user_id
+    ).first()
+
+    if not membership:
+        return jsonify({"error": "You do not have access to this expense"}), 403
+
+    if 'file' not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files['file']
+
+    try:
+        upload_result = cloudinary.uploader.upload(file)
+
+        expense.receipt_url = upload_result['secure_url']
+        db.session.commit()
+
+        return jsonify({
+            "message": "Receipt uploaded successfully",
+            "receipt_url": expense.receipt_url
+        }), 200
+
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": str(e)}), 500
+
+
+@api.route('/expense/<int:expense_id>/receipt', methods=['DELETE'])
+@jwt_required()
+def delete_receipt(expense_id):
+    user_id = int(get_jwt_identity())
+
+    expense = Expense.query.get(expense_id)
+    if not expense:
+        return jsonify({"error": "Expense not found"}), 404
+
+    membership = GroupMember.query.filter_by(
+        group_id=expense.group_id,
+        user_id=user_id
+    ).first()
+
+    if not membership:
+        return jsonify({"error": "You do not have access to this expense"}), 403
+
+    if not expense.receipt_url:
+        return jsonify({"error": "No receipt to delete"}), 400
+
+    expense.receipt_url = None
+    db.session.commit()
+
+    return jsonify({"message": "Receipt removed"}), 200


### PR DESCRIPTION
## Resumen
En este PR se agregó soporte backend para manejar receipts/comprobantes en los expenses.

## Qué se hizo
- Se agregó el campo `receipt_url` al modelo `Expense`
- Se agregó `receipt_url` en el `serialize()` del expense
- Se integró Cloudinary para subir archivos
- Se creó el endpoint `POST /api/expense/<int:expense_id>/receipt`
- Se creó el endpoint `DELETE /api/expense/<int:expense_id>/receipt`

## Cómo funciona
### Upload
El endpoint de upload:
- valida que el expense exista
- valida que el usuario autenticado pertenezca al grupo del expense
- recibe el archivo como `multipart/form-data`
- sube el archivo a Cloudinary
- guarda la `secure_url` en `expense.receipt_url`

### Delete
El endpoint de delete:
- valida que el expense exista
- valida que el usuario autenticado tenga acceso
- elimina la referencia del receipt dejando `receipt_url = None`

## Pruebas realizadas
Se probó manualmente con Postman:
1. Login
2. Crear group
3. Crear expense
4. Subir receipt al expense
5. Eliminar receipt
6. Verificar que `receipt_url` queda en `null`

## Nota
Por ahora el delete elimina la referencia en la base de datos, pero todavía no elimina el archivo físico en Cloudinary.