### PR TITLE
feat: implement debt simplification algorithm (greedy max-heap + TDD)

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -450,6 +450,96 @@ def get_group_expenses(group_id):
         "expenses": response
     }), 200
 
+
+# --- BALANCES (Debt Simplification) ---
+
+@api.route('/groups/<int:group_id>/balances', methods=['GET'])
+@jwt_required()
+def get_group_balances(group_id):
+    """
+    Calculate net balances for all members of a group, then run the
+    greedy debt-simplification algorithm to return the minimum set of
+    peer-to-peer transfers needed to settle all debts.
+
+    Response JSON:
+    {
+      "group_id": int,
+      "balances": { user_id: float },      # raw net balances
+      "transactions": [                     # simplified transfers
+        {"from": user_id, "to": user_id, "amount": float}
+      ],
+      "members": [                          # enriched member info
+        {"id": int, "username": str, "balance": float}
+      ]
+    }
+    """
+    user_id = int(get_jwt_identity())
+
+    # Validate membership
+    membership = GroupMember.query.filter_by(
+        group_id=group_id, user_id=user_id
+    ).first()
+    if not membership:
+        return jsonify({"error": "You do not have access to this group"}), 403
+
+    group = Group.query.get(group_id)
+    if not group:
+        return jsonify({"error": "Group not found"}), 404
+
+    # Get all members of the group
+    members = GroupMember.query.filter_by(group_id=group_id).all()
+    member_ids = [m.user_id for m in members]
+
+    # Initialize balances with Decimal for precision
+    net_balances = {mid: Decimal("0") for mid in member_ids}
+
+    # Get all expenses in this group
+    expenses = Expense.query.filter_by(group_id=group_id).all()
+
+    for expense in expenses:
+        payer_id = expense.paid_by
+        participants = ExpenseParticipant.query.filter_by(
+            expense_id=expense.id
+        ).all()
+
+        for p in participants:
+            amount_owed = Decimal(str(p.amount_owed))
+
+            if p.user_id == payer_id:
+                # The payer's own share — they paid for it, no net change from this
+                # But they ARE credited the full expense amount below
+                pass
+            else:
+                # This participant owes the payer
+                net_balances[p.user_id] = net_balances.get(
+                    p.user_id, Decimal("0")
+                ) - amount_owed
+                net_balances[payer_id] = net_balances.get(
+                    payer_id, Decimal("0")
+                ) + amount_owed
+
+    # Run the simplification algorithm
+    from api.utils import simplify_debts
+    transactions = simplify_debts(net_balances)
+
+    # Build enriched member info
+    members_info = []
+    for mid in member_ids:
+        user = User.query.get(mid)
+        if user:
+            members_info.append({
+                "id": user.id,
+                "username": user.username,
+                "balance": float(net_balances.get(mid, Decimal("0")))
+            })
+
+    return jsonify({
+        "group_id": group_id,
+        "balances": {str(k): float(v) for k, v in net_balances.items()},
+        "transactions": transactions,
+        "members": members_info
+    }), 200
+
 # Actualizar un gasto
 @api.route('/expenses/<int:expense_id>', methods=['PUT'])
 @jwt_required()

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -43,6 +43,88 @@ def generate_sitemap(app):
 
 
 # ============================================
+# DEBT SIMPLIFICATION ALGORITHM
+# Greedy max-heap approach for minimizing
+# the number of transactions in a group.
+# ============================================
+
+def simplify_debts(balances: dict) -> list:
+    """
+    Simplifies a set of net balances into the minimum number of
+    direct peer-to-peer transactions using a greedy algorithm.
+
+    Algorithm (Network Flow / Greedy Max-Heap):
+    1. Filter out users with zero balance (they owe nothing / are owed nothing).
+    2. Separate users into Debtors (negative balance) and Creditors (positive balance).
+    3. Sort both lists by absolute value descending (simulates max-heaps).
+    4. Iteratively pair the largest debtor with the largest creditor:
+       - Transfer the minimum of their absolute balances.
+       - Reduce both balances accordingly.
+       - Remove any user whose balance reaches zero.
+       - Re-sort after each iteration to maintain the greedy invariant.
+    5. Repeat until all balances are zero.
+
+    Args:
+        balances: dict mapping user_id (str or int) to their net balance (Decimal).
+                  Positive = creditor (is owed money).
+                  Negative = debtor (owes money).
+                  The sum of all values MUST equal 0.
+
+    Returns:
+        list of dicts: [{"from": debtor_id, "to": creditor_id, "amount": float}]
+        Amounts are rounded to 2 decimal places.
+    """
+    transactions = []
+
+    # --- Step 1: Build debtors and creditors lists ---
+    # Use Decimal throughout for cent-level precision.
+    debtors = []   # (user_id, abs_amount)  — people who OWE money
+    creditors = [] # (user_id, amount)       — people who ARE OWED money
+
+    for user, balance in balances.items():
+        bal = Decimal(str(balance))
+        if bal < 0:
+            debtors.append([user, abs(bal)])
+        elif bal > 0:
+            creditors.append([user, bal])
+        # bal == 0 → skip (no debt)
+
+    # --- Step 2: Sort descending by amount (greedy: biggest first) ---
+    debtors.sort(key=lambda x: x[1], reverse=True)
+    creditors.sort(key=lambda x: x[1], reverse=True)
+
+    # --- Step 3: Greedy matching loop ---
+    while debtors and creditors:
+        debtor_id, debt_amount = debtors[0]
+        creditor_id, credit_amount = creditors[0]
+
+        # Transfer the smaller of the two amounts
+        transfer = min(debt_amount, credit_amount)
+
+        transactions.append({
+            "from": debtor_id,
+            "to": creditor_id,
+            "amount": float(transfer.quantize(Decimal("0.01")))
+        })
+
+        # Update balances
+        debtors[0][1] -= transfer
+        creditors[0][1] -= transfer
+
+        # Remove settled users
+        if debtors[0][1] == 0:
+            debtors.pop(0)
+        if creditors and creditors[0][1] == 0:
+            creditors.pop(0)
+
+        # Re-sort to maintain greedy invariant
+        debtors.sort(key=lambda x: x[1], reverse=True)
+        creditors.sort(key=lambda x: x[1], reverse=True)
+
+    return transactions
+
+
+# ============================================
 # FRIENDS & DEBTS UTILITIES
 # ============================================
 

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/src/tests/test_algorithm.py
+++ b/src/tests/test_algorithm.py
@@ -1,0 +1,361 @@
+"""
+Comprehensive TDD tests for the Splitty Debt Simplification Algorithm.
+
+Tests MUST be written BEFORE implementation (per TDD Skill).
+All financial computations use Decimal for cent-level precision.
+
+Algorithm under test: simplify_debts(balances: dict[str, Decimal]) -> list[dict]
+  - Input: { user_id: net_balance } where positive = creditor, negative = debtor
+  - Output: [ {"from": debtor, "to": creditor, "amount": float} ]
+"""
+import sys
+import os
+import pytest
+from decimal import Decimal
+
+# Add the api directory to the path so we can import utils directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "api"))
+
+from utils import simplify_debts
+
+
+# ============================================
+# HELPER: Validate that a transaction list
+# fully settles all balances to zero.
+# ============================================
+def _assert_balances_zeroed(balances: dict, transactions: list):
+    """Apply all transactions and assert every balance reaches zero."""
+    remaining = {k: Decimal(str(v)) for k, v in balances.items()}
+    for t in transactions:
+        remaining[t["from"]] += Decimal(str(t["amount"]))
+        remaining[t["to"]] -= Decimal(str(t["amount"]))
+    for user, bal in remaining.items():
+        assert bal == Decimal("0"), (
+            f"User {user} has unsettled balance: {bal}"
+        )
+
+
+def _assert_all_amounts_positive(transactions: list):
+    """Every transaction amount must be > 0."""
+    for t in transactions:
+        assert t["amount"] > 0, f"Non-positive amount in transaction: {t}"
+
+
+# ============================================
+# CASE 1: One payer, multiple debtors
+# "A paid $100 dinner for 4 people (A, B, C, D)"
+# Net: A = +75, B = -25, C = -25, D = -25
+# Expected: 3 transactions, all TO A, each $25.
+# ============================================
+class TestOnePayerMultipleDebtors:
+    def test_transaction_count(self):
+        balances = {
+            "A": Decimal("75.00"),
+            "B": Decimal("-25.00"),
+            "C": Decimal("-25.00"),
+            "D": Decimal("-25.00"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 3
+
+    def test_all_pay_to_creditor(self):
+        balances = {
+            "A": Decimal("75.00"),
+            "B": Decimal("-25.00"),
+            "C": Decimal("-25.00"),
+            "D": Decimal("-25.00"),
+        }
+        txns = simplify_debts(balances)
+        for t in txns:
+            assert t["to"] == "A"
+            assert t["amount"] == 25.0
+
+    def test_balances_zero(self):
+        balances = {
+            "A": Decimal("75.00"),
+            "B": Decimal("-25.00"),
+            "C": Decimal("-25.00"),
+            "D": Decimal("-25.00"),
+        }
+        txns = simplify_debts(balances)
+        _assert_balances_zeroed(balances, txns)
+
+
+# ============================================
+# CASE 2: Cyclic debts (A→B→C→A)
+# A paid 30 split with B → B owes A 15
+# B paid 30 split with C → C owes B 15
+# C paid 30 split with A → A owes C 15
+# Net balance: Everyone = 0.  Expected: 0 transactions.
+# ============================================
+class TestCyclicDebts:
+    def test_perfect_cycle_zero_transactions(self):
+        """Perfect circular debt: everyone's net = 0 → 0 transactions."""
+        balances = {
+            "A": Decimal("0.00"),
+            "B": Decimal("0.00"),
+            "C": Decimal("0.00"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 0
+
+    def test_imperfect_cycle(self):
+        """
+        A→B: $20, B→C: $30, C→A: $10.
+        Net: A = -10, B = -10, C = +20
+        Expected: 2 transactions (A→C: 10, B→C: 10), or optimized to similar.
+        """
+        balances = {
+            "A": Decimal("-10.00"),
+            "B": Decimal("-10.00"),
+            "C": Decimal("20.00"),
+        }
+        txns = simplify_debts(balances)
+        # The algorithm should produce at most 2 transactions
+        assert len(txns) <= 2
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)
+
+
+# ============================================
+# CASE 3: Chain debts (A owes B, B owes C)
+# Net: A = -10, B = 0, C = +10
+# Expected: 1 transaction (A→C: $10), B is eliminated.
+# ============================================
+class TestChainDebts:
+    def test_chain_simplification(self):
+        balances = {
+            "A": Decimal("-10.00"),
+            "B": Decimal("0.00"),
+            "C": Decimal("10.00"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 1
+        assert txns[0]["from"] == "A"
+        assert txns[0]["to"] == "C"
+        assert txns[0]["amount"] == 10.0
+
+    def test_chain_balances_zero(self):
+        balances = {
+            "A": Decimal("-10.00"),
+            "B": Decimal("0.00"),
+            "C": Decimal("10.00"),
+        }
+        txns = simplify_debts(balances)
+        _assert_balances_zeroed(balances, txns)
+
+
+# ============================================
+# CASE 4: Complex multi-creditor, multi-debtor
+# Net: A = -50, B = -25, C = +60, D = +15
+# The greedy algorithm should minimize transactions.
+# ============================================
+class TestComplexSplit:
+    def test_transaction_count(self):
+        balances = {
+            "A": Decimal("-50.00"),
+            "B": Decimal("-25.00"),
+            "C": Decimal("60.00"),
+            "D": Decimal("15.00"),
+        }
+        txns = simplify_debts(balances)
+        # Greedy: A→C(50), B→C(10), B→D(15) = 3 txns
+        assert len(txns) <= 3
+
+    def test_complex_balances_zero(self):
+        balances = {
+            "A": Decimal("-50.00"),
+            "B": Decimal("-25.00"),
+            "C": Decimal("60.00"),
+            "D": Decimal("15.00"),
+        }
+        txns = simplify_debts(balances)
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)
+
+
+# ============================================
+# CASE 5: No debts — all balances zero
+# ============================================
+class TestNoDebts:
+    def test_all_zero(self):
+        balances = {
+            "A": Decimal("0.00"),
+            "B": Decimal("0.00"),
+        }
+        assert len(simplify_debts(balances)) == 0
+
+    def test_empty_dict(self):
+        assert len(simplify_debts({})) == 0
+
+
+# ============================================
+# CASE 6: Single user — edge case
+# ============================================
+class TestSingleUser:
+    def test_single_user_zero(self):
+        balances = {"A": Decimal("0.00")}
+        assert len(simplify_debts(balances)) == 0
+
+
+# ============================================
+# CASE 7: Float precision — recurring decimals
+# Splitting $100 among 3 people:
+# Each owes 33.33, one owes 33.34 (rounding).
+# The function must handle Decimal precision.
+# ============================================
+class TestFloatPrecision:
+    def test_thirds_split(self):
+        """
+        Three-way split of 100.00.
+        Payer: A (keeps 0), Debtors: B and C owe 33.33, D owes 33.34.
+        Net: A = +100.00, B = -33.33, C = -33.33, D = -33.34
+        """
+        balances = {
+            "A": Decimal("100.00"),
+            "B": Decimal("-33.33"),
+            "C": Decimal("-33.33"),
+            "D": Decimal("-33.34"),
+        }
+        txns = simplify_debts(balances)
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)
+
+    def test_penny_precision(self):
+        """
+        Very small amounts — must not lose pennies.
+        """
+        balances = {
+            "A": Decimal("0.01"),
+            "B": Decimal("-0.01"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 1
+        assert txns[0]["amount"] == 0.01
+        _assert_balances_zeroed(balances, txns)
+
+    def test_large_amounts_precision(self):
+        """
+        Large dinner: $9999.99 split across 3 — Decimal must not drift.
+        """
+        total = Decimal("9999.99")
+        each = (total / 3).quantize(Decimal("0.01"))
+        remainder = total - (each * 2)
+        balances = {
+            "A": total,
+            "B": -each,
+            "C": -each,
+            "D": -remainder,
+        }
+        txns = simplify_debts(balances)
+        _assert_balances_zeroed(balances, txns)
+
+
+# ============================================
+# CASE 8: Two equal creditors, one debtor
+# Net: A = +50, B = +50, C = -100
+# Expected: 2 transactions (C→A:50, C→B:50)
+# ============================================
+class TestTwoCreditors:
+    def test_even_split_to_multiple_creditors(self):
+        balances = {
+            "A": Decimal("50.00"),
+            "B": Decimal("50.00"),
+            "C": Decimal("-100.00"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 2
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)
+
+
+# ============================================
+# CASE 9: Many users — stress test
+# 10 users, the sum of balances = 0
+# ============================================
+class TestManyUsers:
+    def test_ten_users(self):
+        balances = {
+            "U1": Decimal("100.00"),
+            "U2": Decimal("50.00"),
+            "U3": Decimal("-30.00"),
+            "U4": Decimal("-20.00"),
+            "U5": Decimal("-10.00"),
+            "U6": Decimal("-15.00"),
+            "U7": Decimal("-25.00"),
+            "U8": Decimal("-10.00"),
+            "U9": Decimal("-5.00"),
+            "U10": Decimal("-35.00"),
+        }
+        # Verify sum = 0
+        assert sum(balances.values()) == Decimal("0.00")
+
+        txns = simplify_debts(balances)
+        # Greedy should produce at most n-1 = 9 transactions
+        assert len(txns) <= 9
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)
+
+
+# ============================================
+# CASE 10: Return format validation
+# Each transaction must be {"from": str, "to": str, "amount": float}
+# ============================================
+class TestReturnFormat:
+    def test_keys_present(self):
+        balances = {
+            "A": Decimal("10.00"),
+            "B": Decimal("-10.00"),
+        }
+        txns = simplify_debts(balances)
+        for t in txns:
+            assert "from" in t
+            assert "to" in t
+            assert "amount" in t
+
+    def test_amount_is_float(self):
+        balances = {
+            "A": Decimal("10.00"),
+            "B": Decimal("-10.00"),
+        }
+        txns = simplify_debts(balances)
+        for t in txns:
+            assert isinstance(t["amount"], float)
+
+    def test_from_to_are_strings(self):
+        balances = {
+            "A": Decimal("10.00"),
+            "B": Decimal("-10.00"),
+        }
+        txns = simplify_debts(balances)
+        for t in txns:
+            assert isinstance(t["from"], str)
+            assert isinstance(t["to"], str)
+
+    def test_no_self_transfers(self):
+        """A person should never pay themselves."""
+        balances = {
+            "A": Decimal("50.00"),
+            "B": Decimal("-30.00"),
+            "C": Decimal("-20.00"),
+        }
+        txns = simplify_debts(balances)
+        for t in txns:
+            assert t["from"] != t["to"], f"Self-transfer detected: {t}"
+
+
+# ============================================
+# CASE 11: Integer user IDs (real-world DB keys)
+# The function must work with int keys too.
+# ============================================
+class TestIntegerUserIds:
+    def test_with_int_keys(self):
+        balances = {
+            1: Decimal("30.00"),
+            2: Decimal("-15.00"),
+            3: Decimal("-15.00"),
+        }
+        txns = simplify_debts(balances)
+        assert len(txns) == 2
+        _assert_balances_zeroed(balances, txns)
+        _assert_all_amounts_positive(txns)


### PR DESCRIPTION
- Add simplify_debts() in src/api/utils.py using greedy max-heap approach
- Add GET /groups/<group_id>/balances endpoint in routes.py
- Add 22 comprehensive pytest tests in src/tests/test_algorithm.py
- Uses Decimal throughout for cent-level financial precision
- Covers: cyclic debts, chain debts, float precision, 10-user stress test